### PR TITLE
Bugfix: changed Url pathname override to a concatenate

### DIFF
--- a/packages/cli/types/schema.ts
+++ b/packages/cli/types/schema.ts
@@ -122,7 +122,7 @@ export async function fetchSchema(
     }
 
     const url = new URL(directus.url);
-    url.pathname = "/schema/snapshot";
+    url.pathname += "/schema/snapshot";
     url.searchParams.set("export", "json");
     url.searchParams.set("access_token", directus.token);
 


### PR DESCRIPTION
This now means https://directus.domain/path/to/directus/schema/snapshot is supported previously it was overwriting the url as such: https://directus.domain/schema/snapshot